### PR TITLE
Add pyproject.toml file to describe all the

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools","setuptools_scm","swig"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,13 @@ setup(
     name='pylibfdt',
     cmdclass = {'build_py' : build_py},
     use_scm_version=True,
-    setup_requires = ['setuptools_scm', 'swig'],
+    setup_requires = ['setuptools_scm'],
     author='Simon Glass <sjg@chromium.org>',
     description='Python binding for libfdt',
     ext_modules=[libfdt_module],
     py_modules=['libfdt'],
     package_dir={'': 'libfdt'},
-    python_requires=">=3.8",
+
     long_description=long_description,
     long_description_content_type="text/plain",
 )


### PR DESCRIPTION
dependency instead of modifying setup.py

This also reverts commit "Add swig dependency":
b980a2764a8db40cc06d4ce32e27c01bc2f58c6b.