### PR TITLE
Update pip installation instructions

### DIFF
--- a/README
+++ b/README
@@ -14,7 +14,7 @@ On Debian distributions:
 
 The module can be installed with pip:
 
-   pip install libfdt
+   pip install pylibfdt
 
 or via setup.py:
 


### PR DESCRIPTION
Fix package name based on: https://pypi.org/project/pylibfdt/.

Fixes #6 