### PR TITLE
pylibfdt: Replace removed SWIG Python 2 compatibility macros

### DIFF
--- a/libfdt/libfdt.i
+++ b/libfdt/libfdt.i
@@ -1136,7 +1136,7 @@ typedef uint32_t fdt32_t;
 	PyObject *buff;
 
 	if ($1) {
-		resultobj = PyString_FromString(
+		resultobj = PyUnicode_FromString(
 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
 		buff = PyByteArray_FromStringAndSize(
 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
@@ -1169,13 +1169,13 @@ typedef uint32_t fdt32_t;
         }
         $1 = PyBytes_AsString($input);
     %#else
-        $1 = PyString_AsString($input);   /* char *str */
+        $1 = PyBytes_AsString($input);   /* char *str */
     %#endif
 }
 
 /* typemaps used for fdt_next_node() */
 %typemap(in, numinputs=1) int *depth (int depth) {
-   depth = (int) PyInt_AsLong($input);
+   depth = (int) PyLong_AsLong($input);
    $1 = &depth;
 }
 


### PR DESCRIPTION
## Summary

Sync the SWIG 4.5.0 compatibility fix from upstream DTC commit
[`5008d1d6a356b8d0a78060da2e1021507d529cff`](https://github.com/dgibson/dtc/commit/5008d1d6a356b8d0a78060da2e1021507d529cff).

SWIG 4.5.0 removed its Python 2 compatibility aliases for `PyInt_*` and
`PyString_*`. The current `libfdt.i` still refers to three of those aliases,
so building pylibfdt from source fails before downstream projects can start
their own builds.

Use the corresponding Python 3 C API names. These are the same functions to
which SWIG previously mapped the removed aliases in its Python 3 code path.

Fixes #11.

Downstream impact: tianocore/edk2#13009.

## Testing

- Python 3.14.2
- SWIG 4.5.0 installed from PyPI
- Windows x64 with MinGW-w64 GCC
- `python setup.py build_ext --compiler=mingw32 --inplace --force`: passed
- Ubuntu 22.04.5, Python 3.10.12, GCC 11.4.0, SWIG 4.5.0
- Linux PEP 517 `pip wheel`: passed
- Installed the generated Linux wheel into a clean virtual environment
- Imported the generated extension and exercised:
  - empty-tree creation
  - node and byte-property insertion
  - property lookup by offset and property-name conversion
  - `next_node()` with its input/output depth parameter
- `git diff --check`: passed
